### PR TITLE
add max supply global state for inflation asset

### DIFF
--- a/src/rgb20/issuer.rs
+++ b/src/rgb20/issuer.rs
@@ -270,7 +270,7 @@ impl PrimaryIssue {
                 self.builder = self
                     .builder
                     .add_asset_tag("inflationAllowance", tag)
-                    .expect("invalid RGB20 schema (max supply mismatch)");
+                    .expect("invalid RGB20 inflation allowance tag (inflation allowance mismatch)");
                 self.inflation = Some(supply)
             }
         }

--- a/src/rgb20/wrapper.rs
+++ b/src/rgb20/wrapper.rs
@@ -251,11 +251,16 @@ impl Rgb20 {
             .sum()
     }
 
-    // max_supply for the inflation asset
+    // Max supply for the inflation asset, if there is no `max supply`, then it will
+    // default to the non-inflatable asset `issued supply`
     pub fn max_supply(&self) -> Amount {
         self.0
             .global("maxSupply")
-            .expect("RGB20 interface requires global `maxSupply`")
+            .unwrap_or(
+                self.0
+                    .global("issuedSupply")
+                    .expect("RGB20 interface requires global `issuedSupply`"),
+            )
             .iter()
             .map(Amount::from_strict_val_unchecked)
             .sum()

--- a/src/rgb20/wrapper.rs
+++ b/src/rgb20/wrapper.rs
@@ -256,11 +256,11 @@ impl Rgb20 {
     pub fn max_supply(&self) -> Amount {
         self.0
             .global("maxSupply")
-            .unwrap_or(
+            .unwrap_or_else(|_| {
                 self.0
                     .global("issuedSupply")
-                    .expect("RGB20 interface requires global `issuedSupply`"),
-            )
+                    .expect("RGB20 interface requires global `issuedSupply`")
+            })
             .iter()
             .map(Amount::from_strict_val_unchecked)
             .sum()

--- a/src/rgb20/wrapper.rs
+++ b/src/rgb20/wrapper.rs
@@ -251,6 +251,16 @@ impl Rgb20 {
             .sum()
     }
 
+    // max_supply for the inflation asset
+    pub fn max_supply(&self) -> Amount {
+        self.0
+            .global("maxSupply")
+            .expect("RGB20 interface requires global `maxSupply`")
+            .iter()
+            .map(Amount::from_strict_val_unchecked)
+            .sum()
+    }
+
     pub fn total_burned_supply(&self) -> Amount {
         self.0
             .global("burnedSupply")


### PR DESCRIPTION

Description:

In rgb20 Inflation asset iface, there are `issuedSupply` and `maxSupply` in the global state, here I try to add the `maxSupply` method for the rgb-interface.