### PR TITLE
fix add asset tag

### DIFF
--- a/src/rgb20/issuer.rs
+++ b/src/rgb20/issuer.rs
@@ -270,7 +270,7 @@ impl PrimaryIssue {
                 self.builder = self
                     .builder
                     .add_asset_tag("inflationAllowance", tag)
-                    .expect("invalid RGB20 schema (max supply mismatch)");
+                    .expect("invalid RGB20 inflation allowance tag (inflation allowance mismatch)");
                 self.inflation = Some(supply)
             }
         }


### PR DESCRIPTION

Description:

Here we are building the `add_asset_tag`  method for the `inflationAllowance` state, I think it should not be `max supply mismatch`, so I change it to `inflation allowance mismatch`.