### PR TITLE
make rgb-std's fs feature optional in rgb-interfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,13 @@ strict_types = "2.7.0-beta.4"
 aluvm = "0.11.0-beta.6"
 bp-core = "0.11.0-beta.6"
 chrono = "0.4.37"
-rgb-std = { version = "0.11.0-beta.6", features = ["fs"] }
+rgb-std = { version = "0.11.0-beta.6" }
 serde_crate = { package = "serde", version = "1.0", optional = true }
 serde_json = "1.0"
 sha2 = "0.10.8"
 
 [features]
 default = []
-all = ["serde"]
+all = ["serde", "fs"]
 serde = ["serde_crate", "rgb-std/serde", "chrono/serde"]
+fs = ["rgb-std/fs"]


### PR DESCRIPTION
implementation: https://github.com/RGB-WG/RFC/issues/9
